### PR TITLE
[HEALTH-5208] Add support in ObjectiveAvro to read avro files

### DIFF
--- a/Avro-C/src/codec.c
+++ b/Avro-C/src/codec.c
@@ -25,9 +25,9 @@
 #    include <byteswap.h>
 #  endif
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 #include <zlib.h>
-//#endif
+#endif
 #ifdef LZMA_CODEC
 #include <lzma.h>
 #endif
@@ -188,7 +188,7 @@ static int reset_snappy(avro_codec_t c)
 
 /* Deflate codec */
 
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 
 struct codec_data_deflate {
 	z_stream deflate;
@@ -378,7 +378,7 @@ static int reset_deflate(avro_codec_t c)
 	return 0;
 }
 
-//#endif // DEFLATE_CODEC
+#endif // DEFLATE_CODEC
 
 /* LZMA codec */
 
@@ -524,11 +524,11 @@ int avro_codec(avro_codec_t codec, const char *type)
 	}
 #endif
 
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	if (strcmp("deflate", type) == 0) {
 		return codec_deflate(codec);
 	}
-//#endif
+#endif
 
 #ifdef LZMA_CODEC
 	if (strcmp("lzma", type) == 0) {
@@ -554,10 +554,10 @@ int avro_codec_encode(avro_codec_t c, void * data, int64_t len)
 	case AVRO_CODEC_SNAPPY:
 		return encode_snappy(c, data, len);
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return encode_deflate(c, data, len);
-//#endif
+#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return encode_lzma(c, data, len);
@@ -577,10 +577,10 @@ int avro_codec_decode(avro_codec_t c, void * data, int64_t len)
 	case AVRO_CODEC_SNAPPY:
 		return decode_snappy(c, data, len);
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return decode_deflate(c, data, len);
-//#endif
+#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return decode_lzma(c, data, len);
@@ -600,10 +600,10 @@ int avro_codec_reset(avro_codec_t c)
 	case AVRO_CODEC_SNAPPY:
 		return reset_snappy(c);
 #endif
-//#ifdef DEFLATE_CODEC
+#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return reset_deflate(c);
-//#endif
+#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return reset_lzma(c);

--- a/Avro-C/src/codec.c
+++ b/Avro-C/src/codec.c
@@ -25,9 +25,9 @@
 #    include <byteswap.h>
 #  endif
 #endif
-#ifdef DEFLATE_CODEC
+//#ifdef DEFLATE_CODEC
 #include <zlib.h>
-#endif
+//#endif
 #ifdef LZMA_CODEC
 #include <lzma.h>
 #endif
@@ -188,7 +188,7 @@ static int reset_snappy(avro_codec_t c)
 
 /* Deflate codec */
 
-#ifdef DEFLATE_CODEC
+//#ifdef DEFLATE_CODEC
 
 struct codec_data_deflate {
 	z_stream deflate;
@@ -378,7 +378,7 @@ static int reset_deflate(avro_codec_t c)
 	return 0;
 }
 
-#endif // DEFLATE_CODEC
+//#endif // DEFLATE_CODEC
 
 /* LZMA codec */
 
@@ -524,11 +524,11 @@ int avro_codec(avro_codec_t codec, const char *type)
 	}
 #endif
 
-#ifdef DEFLATE_CODEC
+//#ifdef DEFLATE_CODEC
 	if (strcmp("deflate", type) == 0) {
 		return codec_deflate(codec);
 	}
-#endif
+//#endif
 
 #ifdef LZMA_CODEC
 	if (strcmp("lzma", type) == 0) {
@@ -554,10 +554,10 @@ int avro_codec_encode(avro_codec_t c, void * data, int64_t len)
 	case AVRO_CODEC_SNAPPY:
 		return encode_snappy(c, data, len);
 #endif
-#ifdef DEFLATE_CODEC
+//#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return encode_deflate(c, data, len);
-#endif
+//#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return encode_lzma(c, data, len);
@@ -577,10 +577,10 @@ int avro_codec_decode(avro_codec_t c, void * data, int64_t len)
 	case AVRO_CODEC_SNAPPY:
 		return decode_snappy(c, data, len);
 #endif
-#ifdef DEFLATE_CODEC
+//#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return decode_deflate(c, data, len);
-#endif
+//#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return decode_lzma(c, data, len);
@@ -600,10 +600,10 @@ int avro_codec_reset(avro_codec_t c)
 	case AVRO_CODEC_SNAPPY:
 		return reset_snappy(c);
 #endif
-#ifdef DEFLATE_CODEC
+//#ifdef DEFLATE_CODEC
 	case AVRO_CODEC_DEFLATE:
 		return reset_deflate(c);
-#endif
+//#endif
 #ifdef LZMA_CODEC
 	case AVRO_CODEC_LZMA:
 		return reset_lzma(c);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # ObjectiveAvro CHANGELOG
 
+## 0.4.0
+
+Add support for writing full .avro files.
+
+## 0.3.0
+
+Add support for unions and defaults.
+
+## 0.2.0
+
+Carthage compatibility.
+
 ## 0.1.0
 
 Initial release.

--- a/Classes/OAVAvroSerialization.h
+++ b/Classes/OAVAvroSerialization.h
@@ -15,6 +15,22 @@
 @interface OAVAvroSerialization : NSObject <NSCopying, NSCoding>
 
 /**
+ * Serializes a complete Avro file to disk. Unlike `dataFromJSONObject`, this
+ * includes the header and schema, yielding a complete, transferrable file.
+ *
+ * @param jsonObjects   An array of objects to be encoded
+ * @param filePath      The path to which to write the Avro file
+ * @param schemaName    The schema name used to describe the object
+ * @param error         A pointer to the error object that will represent any errors ocurred
+ *
+ * @return A BOOL, `YES` if writing succeeded, `NO` if it failed
+ */
+- (BOOL)writeJSONObjects:(NSArray *)jsonObjects
+                  toFile:(NSString *)filePath
+          forSchemaNamed:(NSString *)schemaName
+                   error:(NSError * __autoreleasing *)error;
+
+/**
  *  Serializes a JSON object to NSData, containing the Avro-encoded object.
  *
  *  @param jsonObject The object to be encoded

--- a/Classes/OAVAvroSerialization.h
+++ b/Classes/OAVAvroSerialization.h
@@ -21,7 +21,7 @@
 typedef void * OAVFileWriterToken;
 
 /**
- * Open a file for writing with the given schema. The schema must already be
+ * Start a file for writing with the given schema. The schema must already be
  * registered with this serialization object.
  *
  * @param filePath      The path to which to write the Avro file
@@ -33,6 +33,17 @@ typedef void * OAVFileWriterToken;
 - (nullable OAVFileWriterToken)startFile:(nonnull NSString *)filePath
                           forSchemaNamed:(nonnull NSString *)schemaName
                                    error:( NSError * _Nullable  __autoreleasing *)error;
+/**
+ * Re-open a file for writing. The file must already have been created with
+ * startFile:forSchemaNamed:error:.
+ *
+ * @param filePath      The path to which to write the Avro file
+ * @param error         A pointer to the error object that will represent any errors ocurred
+ *
+ * @return An `OAVFileWriterToken`, to be used in future calls.
+ */
+- (nullable OAVFileWriterToken)openFile:(NSString *)filePath
+                                  error:(NSError * __autoreleasing *)error;
 
 /**
  * Serializes the given JSON objects to the already-open file. Can be called
@@ -55,7 +66,7 @@ typedef void * OAVFileWriterToken;
  *
  * @param writer        The token obtained by calling startFile:forSchemaNamed:
  */
-- (void)endFile:(nonnull OAVFileWriterToken)writer;
+- (void)closeFile:(nonnull OAVFileWriterToken)writer;
 
 /**
  * Serializes a complete Avro file to disk. Unlike `dataFromJSONObject`, this

--- a/Classes/OAVAvroSerialization.h
+++ b/Classes/OAVAvroSerialization.h
@@ -15,6 +15,49 @@
 @interface OAVAvroSerialization : NSObject <NSCopying, NSCoding>
 
 /**
+ * An opaque token type used to track a file to which the consumer is writing.
+ * @discussion Should be used only as a token; do not free or do anything else weird.
+ */
+typedef void * OAVFileWriterToken;
+
+/**
+ * Open a file for writing with the given schema. The schema must already be
+ * registered with this serialization object.
+ *
+ * @param filePath      The path to which to write the Avro file
+ * @param schemaName    The schema name used to describe the object
+ * @param error         A pointer to the error object that will represent any errors ocurred
+ *
+ * @return An `OAVFileWriterToken`, to be used in future calls.
+ */
+- (nullable OAVFileWriterToken)startFile:(nonnull NSString *)filePath
+                          forSchemaNamed:(nonnull NSString *)schemaName
+                                   error:( NSError * _Nullable  __autoreleasing *)error;
+
+/**
+ * Serializes the given JSON objects to the already-open file. Can be called
+ * multiple times with different objects.
+ *
+ * @param jsonObjects   An array of objects to be encoded
+ * @param writer        The token obtained by calling startFile:forSchemaNamed:
+ * @param schemaName    The schema name used to describe the object
+ * @param error         A pointer to the error object that will represent any errors ocurred
+ *
+ * @return A BOOL, `YES` if writing succeeded, `NO` if it failed
+ */
+- (BOOL)writeJSONObjects:(nonnull NSArray *)jsonObjects
+                toWriter:(nonnull OAVFileWriterToken)writer
+          forSchemaNamed:(nonnull NSString *)schemaName
+                   error:( NSError * _Nullable  __autoreleasing *)error;
+
+/**
+ * Close the given file, finalizing it and making it ready for use.
+ *
+ * @param writer        The token obtained by calling startFile:forSchemaNamed:
+ */
+- (void)endFile:(nonnull OAVFileWriterToken)writer;
+
+/**
  * Serializes a complete Avro file to disk. Unlike `dataFromJSONObject`, this
  * includes the header and schema, yielding a complete, transferrable file.
  *
@@ -25,10 +68,10 @@
  *
  * @return A BOOL, `YES` if writing succeeded, `NO` if it failed
  */
-- (BOOL)writeJSONObjects:(NSArray *)jsonObjects
-                  toFile:(NSString *)filePath
-          forSchemaNamed:(NSString *)schemaName
-                   error:(NSError * __autoreleasing *)error;
+- (BOOL)writeJSONObjects:(nonnull NSArray *)jsonObjects
+                  toFile:(nonnull NSString *)filePath
+          forSchemaNamed:(nonnull NSString *)schemaName
+                   error:( NSError * _Nullable  __autoreleasing *)error;
 
 /**
  *  Serializes a JSON object to NSData, containing the Avro-encoded object.
@@ -39,8 +82,8 @@
  *
  *  @return An NSData object, containing the result of serialization to Avro format
  */
-- (NSData *)dataFromJSONObject:(id)jsonObject forSchemaNamed:(NSString *)schemaName
-                         error:(NSError * __autoreleasing *)error;
+- (nullable NSData *)dataFromJSONObject:(nonnull id)jsonObject forSchemaNamed:(nonnull NSString *)schemaName
+                         error:( NSError * _Nullable  __autoreleasing *)error;
 
 /**
  *  Creates a Foundation object from a NSData Avro object.
@@ -51,8 +94,8 @@
  *
  *  @return A Foundation representation of the Avro encoded object
  */
-- (id)JSONObjectFromData:(NSData *)data forSchemaNamed:(NSString *)schemaName
-                   error:(NSError * __autoreleasing *)error;
+- (nullable id)JSONObjectFromData:(nonnull NSData *)data forSchemaNamed:(nonnull NSString *)schemaName
+                   error:( NSError * _Nullable  __autoreleasing *)error;
 
 /**
  *  Register a schema so the wrapper can serialize objects later.
@@ -62,6 +105,6 @@
  *
  *  @return Whether the schema was registered or not
  */
-- (BOOL)registerSchema:(NSString *)schema error:(NSError * __autoreleasing *)error;
+- (BOOL)registerSchema:(nonnull NSString *)schema error:( NSError * _Nullable  __autoreleasing *)error;
 
 @end

--- a/Classes/OAVAvroSerialization.h
+++ b/Classes/OAVAvroSerialization.h
@@ -109,6 +109,16 @@ typedef void * OAVFileWriterToken;
                    error:( NSError * _Nullable  __autoreleasing *)error;
 
 /**
+*  Creates a Foundation object from Avro written file.
+*
+*  @param filePath  fiel path to saved avro file
+*  @param error      A pointer to the error object that will represent any errors ocurred
+*
+*  @return A Foundation representation of the Avro encoded object
+*/
+- (NSArray *)JSONObjectsFromFile:(NSString *)filePath error:(NSError * __autoreleasing *)error;
+
+/**
  *  Register a schema so the wrapper can serialize objects later.
  *
  *  @param schema A JSON describing the Avro schema

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -358,9 +358,10 @@
 
     // defaults
     if (([values isKindOfClass:[NSNull class]] || values == nil)
-        && schema[@"default"] != nil
-        && schema[@"default"] != values) {
-        return [self valueForSchema:schema values:schema[@"default"]];
+        && schema[@"default"] != nil) {
+        NSMutableDictionary *defaultSchema = [schema mutableCopy];
+        defaultSchema[@"default"] = nil;
+        return [self valueForSchema:defaultSchema values:schema[@"default"]];
     }
     
     // union types

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -83,7 +83,7 @@
     }
     
     avro_file_writer_t writer = NULL;
-    if (avro_file_writer_create_with_codec([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer, "deflate", 0) != 0) {
+    if (avro_file_writer_create([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer) != 0) {
         if (error != NULL) {
             NSString *errorMsg = [NSString stringWithFormat:@"Couldn't create file writer: %s (%d)", avro_strerror(), errno];
             NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedStringFromTable(errorMsg, @"ObjectiveAvro", nil)};

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -147,7 +147,6 @@
 
 - (void)closeFile:(avro_file_writer_t)writer {
     avro_file_writer_close(writer);
-    avro_writer_free(writer);
 }
 
 - (BOOL)writeJSONObjects:(NSArray *)jsonObjects

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -375,9 +375,12 @@
             unionSchema[@"type"] = unionType;
             avro_datum_t unionValue = [self valueForSchema:unionSchema values:values];
             if (unionValue != nil) {
-                value = avro_union([self schemaFromName:schema],
+                avro_schema_t avroSchema = [self schemaFromName:schema];
+                value = avro_union(avroSchema,
                                    [(NSArray *)type indexOfObject:unionType],
                                    unionValue);
+                avro_schema_decref(avroSchema);
+                avro_datum_decref(unionValue);
                 return value;
             }
         }

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -83,7 +83,7 @@
     }
     
     avro_file_writer_t writer = NULL;
-    if (avro_file_writer_create([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer) != 0) {
+    if (avro_file_writer_create_with_codec([filePath cStringUsingEncoding:NSUTF8StringEncoding], schema, &writer, "deflate", 0) != 0) {
         if (error != NULL) {
             NSString *errorMsg = [NSString stringWithFormat:@"Couldn't create file writer: %s (%d)", avro_strerror(), errno];
             NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedStringFromTable(errorMsg, @"ObjectiveAvro", nil)};

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -95,6 +95,22 @@
     return writer;
 }
 
+- (OAVFileWriterToken)openFile:(NSString *)filePath
+                         error:(NSError * __autoreleasing *)error {
+    NSParameterAssert(filePath);
+    avro_file_writer_t writer = NULL;
+    if (avro_file_writer_open([filePath cStringUsingEncoding:NSUTF8StringEncoding], &writer) != 0) {
+        if (error != NULL) {
+            NSString *errorMsg = [NSString stringWithFormat:@"Couldn't open file writer: %s (%d)", avro_strerror(), errno];
+            NSDictionary *userInfo = @{NSLocalizedDescriptionKey:NSLocalizedStringFromTable(errorMsg, @"ObjectiveAvro", nil)};
+            *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadNoSuchFileError
+                                     userInfo:userInfo];
+        }
+        return nil;
+    }
+    return writer;
+}
+
 - (BOOL)writeJSONObjects:(NSArray *)jsonObjects
                 toWriter:(avro_file_writer_t)writer
           forSchemaNamed:(NSString *)schemaName
@@ -127,7 +143,7 @@
     return YES;
 }
 
-- (void)endFile:(avro_file_writer_t)writer {
+- (void)closeFile:(avro_file_writer_t)writer {
     avro_file_writer_close(writer);
 }
 
@@ -146,7 +162,7 @@
     if (![self writeJSONObjects:jsonObjects toWriter:writer forSchemaNamed:schemaName error:&error]) {
         return NO;
     } 
-    [self endFile:writer];
+    [self closeFile:writer];
     return YES;
 }
 

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -379,8 +379,9 @@
             }
         }
     }
-    
-    if ([type isEqualToString:@"string"] && [values isKindOfClass:[NSString class]]) {
+    if ([values isKindOfClass:[NSNull class]] && ![type isEqualToString:@"null"]) {
+        // if we're given a null unexpectedly, we can't do much
+    } else if ([type isEqualToString:@"string"] && [values isKindOfClass:[NSString class]]) {
         value = avro_string([values cStringUsingEncoding:NSUTF8StringEncoding]);
     } else if ([type isEqualToString:@"float"]) {
         value = avro_float([values floatValue]);

--- a/Classes/OAVAvroSerialization.m
+++ b/Classes/OAVAvroSerialization.m
@@ -137,14 +137,17 @@
                 *error = [NSError errorWithDomain:NSCocoaErrorDomain code:NSFileReadNoSuchFileError
                                          userInfo:userInfo];
             }
+            avro_datum_decref(datum);
             return NO;
         }
+        avro_datum_decref(datum);
     }
     return YES;
 }
 
 - (void)closeFile:(avro_file_writer_t)writer {
     avro_file_writer_close(writer);
+    avro_writer_free(writer);
 }
 
 - (BOOL)writeJSONObjects:(NSArray *)jsonObjects

--- a/Example/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/Example/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6B16B29320476209004276D5 /* person_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 6B16B29220473FD3004276D5 /* person_schema.json */; };
 		D476EB8618D332AB0060579C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8518D332AB0060579C /* Foundation.framework */; };
 		D476EB8818D332AB0060579C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8718D332AB0060579C /* CoreGraphics.framework */; };
 		D476EB8A18D332AB0060579C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8918D332AB0060579C /* UIKit.framework */; };
@@ -270,6 +271,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D476EBAF18D332AB0060579C /* InfoPlist.strings in Resources */,
+				6B16B29320476209004276D5 /* person_schema.json in Resources */,
 				D476EBBF18D33EDF0060579C /* people.json in Resources */,
 				D476EBBE18D33EDF0060579C /* people_schema.json in Resources */,
 			);

--- a/Example/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/Example/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		245325EB28824D6A886A50C3 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 078BCDBD35B242F89119581D /* libPods.a */; };
 		D476EB8618D332AB0060579C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8518D332AB0060579C /* Foundation.framework */; };
 		D476EB8818D332AB0060579C /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8718D332AB0060579C /* CoreGraphics.framework */; };
 		D476EB8A18D332AB0060579C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8918D332AB0060579C /* UIKit.framework */; };
@@ -22,7 +21,6 @@
 		D476EBA718D332AB0060579C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D476EB8918D332AB0060579C /* UIKit.framework */; };
 		D476EBAF18D332AB0060579C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D476EBAD18D332AB0060579C /* InfoPlist.strings */; };
 		D476EBB118D332AB0060579C /* ObjectiveAvroTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D476EBB018D332AB0060579C /* ObjectiveAvroTests.m */; };
-		D476EBBD18D33EDF0060579C /* person_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = D476EBBA18D33EDF0060579C /* person_schema.json */; };
 		D476EBBE18D33EDF0060579C /* people_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = D476EBBB18D33EDF0060579C /* people_schema.json */; };
 		D476EBBF18D33EDF0060579C /* people.json in Resources */ = {isa = PBXBuildFile; fileRef = D476EBBC18D33EDF0060579C /* people.json */; };
 		E9DC513D5C22400AB51FEB38 /* libPods-ObjectiveAvroTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A0E574D9328F40B4AABF86A6 /* libPods-ObjectiveAvroTests.a */; };
@@ -40,6 +38,9 @@
 
 /* Begin PBXFileReference section */
 		078BCDBD35B242F89119581D /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		361896E12B93748B02D76DD0 /* Pods-ObjectiveAvroTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveAvroTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests.debug.xcconfig"; sourceTree = "<group>"; };
+		50E5EAA33596824F4E023579 /* Pods-ObjectiveAvroTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveAvroTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests.release.xcconfig"; sourceTree = "<group>"; };
+		6B16B29220473FD3004276D5 /* person_schema.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = person_schema.json; path = ../ObjectiveAvro/person_schema.json; sourceTree = "<group>"; };
 		A0E574D9328F40B4AABF86A6 /* libPods-ObjectiveAvroTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ObjectiveAvroTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D476EB8218D332AB0060579C /* ObjectiveAvro.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjectiveAvro.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D476EB8518D332AB0060579C /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -60,11 +61,9 @@
 		D476EBAC18D332AB0060579C /* ObjectiveAvroTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ObjectiveAvroTests-Info.plist"; sourceTree = "<group>"; };
 		D476EBAE18D332AB0060579C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D476EBB018D332AB0060579C /* ObjectiveAvroTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveAvroTests.m; sourceTree = "<group>"; };
-		D476EBBA18D33EDF0060579C /* person_schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = person_schema.json; sourceTree = "<group>"; };
 		D476EBBB18D33EDF0060579C /* people_schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = people_schema.json; sourceTree = "<group>"; };
 		D476EBBC18D33EDF0060579C /* people.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = people.json; sourceTree = "<group>"; };
 		E41214375EEC429981B0AEFF /* Pods-ObjectiveAvroTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveAvroTests.xcconfig"; path = "Pods/Pods-ObjectiveAvroTests.xcconfig"; sourceTree = "<group>"; };
-		F3AECFDA32714A7CA977D06E /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,7 +74,6 @@
 				D476EB8818D332AB0060579C /* CoreGraphics.framework in Frameworks */,
 				D476EB8A18D332AB0060579C /* UIKit.framework in Frameworks */,
 				D476EB8618D332AB0060579C /* Foundation.framework in Frameworks */,
-				245325EB28824D6A886A50C3 /* libPods.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,6 +91,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A2E120F9EB7C589127767764 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				361896E12B93748B02D76DD0 /* Pods-ObjectiveAvroTests.debug.xcconfig */,
+				50E5EAA33596824F4E023579 /* Pods-ObjectiveAvroTests.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		D476EB7918D332AB0060579C = {
 			isa = PBXGroup;
 			children = (
@@ -100,8 +107,8 @@
 				D476EBAA18D332AB0060579C /* ObjectiveAvroTests */,
 				D476EB8418D332AB0060579C /* Frameworks */,
 				D476EB8318D332AB0060579C /* Products */,
-				F3AECFDA32714A7CA977D06E /* Pods.xcconfig */,
 				E41214375EEC429981B0AEFF /* Pods-ObjectiveAvroTests.xcconfig */,
+				A2E120F9EB7C589127767764 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -155,7 +162,7 @@
 		D476EBAA18D332AB0060579C /* ObjectiveAvroTests */ = {
 			isa = PBXGroup;
 			children = (
-				D476EBBA18D33EDF0060579C /* person_schema.json */,
+				6B16B29220473FD3004276D5 /* person_schema.json */,
 				D476EBBB18D33EDF0060579C /* people_schema.json */,
 				D476EBBC18D33EDF0060579C /* people.json */,
 				D476EBB018D332AB0060579C /* ObjectiveAvroTests.m */,
@@ -180,11 +187,9 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D476EBB418D332AB0060579C /* Build configuration list for PBXNativeTarget "ObjectiveAvro" */;
 			buildPhases = (
-				A24CCF6ED4414117872675FD /* Check Pods Manifest.lock */,
 				D476EB7E18D332AB0060579C /* Sources */,
 				D476EB7F18D332AB0060579C /* Frameworks */,
 				D476EB8018D332AB0060579C /* Resources */,
-				EEAC08EDDED344DBA47BF2DE /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -199,11 +204,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D476EBB718D332AB0060579C /* Build configuration list for PBXNativeTarget "ObjectiveAvroTests" */;
 			buildPhases = (
-				2DEADF24766B401D8143B3C3 /* Check Pods Manifest.lock */,
+				2DEADF24766B401D8143B3C3 /* [CP] Check Pods Manifest.lock */,
 				D476EB9F18D332AB0060579C /* Sources */,
 				D476EBA018D332AB0060579C /* Frameworks */,
 				D476EBA118D332AB0060579C /* Resources */,
-				E840297798744A91B4B55D09 /* Copy Pods Resources */,
+				E840297798744A91B4B55D09 /* [CP] Copy Pods Resources */,
+				9AE2F935AC2EF6C56B9A8733 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -221,7 +227,7 @@
 		D476EB7A18D332AB0060579C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0920;
 				ORGANIZATIONNAME = Movile;
 				TargetAttributes = {
 					D476EBA218D332AB0060579C = {
@@ -264,7 +270,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D476EBAF18D332AB0060579C /* InfoPlist.strings in Resources */,
-				D476EBBD18D33EDF0060579C /* person_schema.json in Resources */,
 				D476EBBF18D33EDF0060579C /* people.json in Resources */,
 				D476EBBE18D33EDF0060579C /* people_schema.json in Resources */,
 			);
@@ -273,64 +278,52 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2DEADF24766B401D8143B3C3 /* Check Pods Manifest.lock */ = {
+		2DEADF24766B401D8143B3C3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ObjectiveAvroTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A24CCF6ED4414117872675FD /* Check Pods Manifest.lock */ = {
+		9AE2F935AC2EF6C56B9A8733 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E840297798744A91B4B55D09 /* Copy Pods Resources */ = {
+		E840297798744A91B4B55D09 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "Copy Pods Resources";
+			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-ObjectiveAvroTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		EEAC08EDDED344DBA47BF2DE /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -400,18 +393,30 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -424,7 +429,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
@@ -438,25 +443,36 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -464,13 +480,14 @@
 		};
 		D476EBB518D332AB0060579C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F3AECFDA32714A7CA977D06E /* Pods.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ObjectiveAvro/ObjectiveAvro-Prefix.pch";
 				INFOPLIST_FILE = "ObjectiveAvro/ObjectiveAvro-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.movile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -478,13 +495,14 @@
 		};
 		D476EBB618D332AB0060579C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F3AECFDA32714A7CA977D06E /* Pods.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ObjectiveAvro/ObjectiveAvro-Prefix.pch";
 				INFOPLIST_FILE = "ObjectiveAvro/ObjectiveAvro-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.movile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -492,7 +510,7 @@
 		};
 		D476EBB818D332AB0060579C /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E41214375EEC429981B0AEFF /* Pods-ObjectiveAvroTests.xcconfig */;
+			baseConfigurationReference = 361896E12B93748B02D76DD0 /* Pods-ObjectiveAvroTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ObjectiveAvro.app/ObjectiveAvro";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -507,6 +525,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = "ObjectiveAvroTests/ObjectiveAvroTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.movile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;
@@ -515,7 +534,7 @@
 		};
 		D476EBB918D332AB0060579C /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E41214375EEC429981B0AEFF /* Pods-ObjectiveAvroTests.xcconfig */;
+			baseConfigurationReference = 50E5EAA33596824F4E023579 /* Pods-ObjectiveAvroTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ObjectiveAvro.app/ObjectiveAvro";
 				FRAMEWORK_SEARCH_PATHS = (
@@ -526,6 +545,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ObjectiveAvro/ObjectiveAvro-Prefix.pch";
 				INFOPLIST_FILE = "ObjectiveAvroTests/ObjectiveAvroTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.movile.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
 				WRAPPER_EXTENSION = xctest;

--- a/Example/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/Example/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -209,8 +209,6 @@
 				D476EB9F18D332AB0060579C /* Sources */,
 				D476EBA018D332AB0060579C /* Frameworks */,
 				D476EBA118D332AB0060579C /* Resources */,
-				E840297798744A91B4B55D09 /* [CP] Copy Pods Resources */,
-				9AE2F935AC2EF6C56B9A8733 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -228,7 +226,7 @@
 		D476EB7A18D332AB0060579C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = Movile;
 				TargetAttributes = {
 					D476EBA218D332AB0060579C = {
@@ -241,6 +239,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -296,36 +295,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		9AE2F935AC2EF6C56B9A8733 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E840297798744A91B4B55D09 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-ObjectiveAvroTests/Pods-ObjectiveAvroTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -391,6 +360,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -399,12 +369,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -441,6 +413,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -449,12 +422,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -525,6 +500,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"DEFLATE_CODEC=1",
 				);
 				INFOPLIST_FILE = "ObjectiveAvroTests/ObjectiveAvroTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.movile.${PRODUCT_NAME:rfc1034identifier}";

--- a/Example/ObjectiveAvro/ObjectiveAvro-Info.plist
+++ b/Example/ObjectiveAvro/ObjectiveAvro-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.movile.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Example/ObjectiveAvro/person_schema.json
+++ b/Example/ObjectiveAvro/person_schema.json
@@ -9,7 +9,7 @@
         },
         {
             "name": "country",
-            "type": "string"
+            "type": ["null", "string"]
         },
         {
             "name": "age",

--- a/Example/ObjectiveAvroTests/ObjectiveAvroTests-Info.plist
+++ b/Example/ObjectiveAvroTests/ObjectiveAvroTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.movile.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -477,7 +477,7 @@
 }
 
 - (void)testDefault {
-    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"int\", \"string\"], \"default\": 10}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"DefaultTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"int\", \"string\"], \"default\": 10}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
     
     OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
     [avro registerSchema:schema error:NULL];
@@ -492,6 +492,23 @@
     
     expect(error).to.beNil();
     expect(numberFromAvro).to.equal(@{@"int": @10});
+}
+
+- (void)testNumericDefault {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"NumericDefaultTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"test\",\"type\":[\"null\", \"long\"], \"default\": null}]}";
+    
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+    
+    
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"test": @10} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    expect(error).to.beNil();
+    expect(data).toNot.beNil();
+    
+    data = [avro dataFromJSONObject:@{@"test": @"null"} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    expect(error).to.beNil();
+    expect(data).toNot.beNil();
 }
 
 @end

--- a/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -179,7 +179,7 @@
 }
 
 - (void)testMissingFieldAvroSerialization {
-    NSString *json = @"{\"people\":[{\"name\":\"Marcelo Fabri\",\"age\":20},{\"name\":\"Tim Cook\",\"country\":\"USA\",\"age\":53},{\"name\":\"Steve Wozniak\",\"country\":\"USA\",\"age\":63},{\"name\":\"Bill Gates\",\"country\":\"USA\",\"age\":58}],\"generated_timestamp\":1389376800000}";
+    NSString *json = @"{\"people\":[{\"name\":\"Marcelo Fabri\"},{\"name\":\"Tim Cook\",\"country\":\"USA\",\"age\":53},{\"name\":\"Steve Wozniak\",\"country\":\"USA\",\"age\":63},{\"name\":\"Bill Gates\",\"country\":\"USA\",\"age\":58}],\"generated_timestamp\":1389376800000}";
     
     NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:[json dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
     
@@ -291,7 +291,7 @@
         NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"FloatTest" error:&error][@"float_value"];
         
         expect(error).to.beNil();
-        expect(numberFromAvro).to.equal(number);
+        expect(numberFromAvro).to.beCloseToWithin(number, .01);
     }
 }
 

--- a/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -494,7 +494,7 @@
     expect(numberFromAvro).to.equal(@{@"int": @10});
 }
 
-- (void)testNumericDefault {
+- (void)testNullDefault {
     NSString *schema = @"{\"type\":\"record\",\"name\":\"NumericDefaultTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"test\",\"type\":[\"null\", \"long\"], \"default\": null}]}";
     
     OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
@@ -506,7 +506,7 @@
     expect(error).to.beNil();
     expect(data).toNot.beNil();
     
-    data = [avro dataFromJSONObject:@{@"test": @"null"} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    data = [avro dataFromJSONObject:@{@"test": [NSNull null]} forSchemaNamed:@"NumericDefaultTest" error:&error];
     expect(error).to.beNil();
     expect(data).toNot.beNil();
 }

--- a/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -395,4 +395,49 @@
     expect(bytesFromAvro).to.equal(bytes);
 }
 
+- (void)testUnionType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"null\", \"string\"],  \"default\": null}]}";
+    
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+    
+    
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"union_value": [NSNull null]} forSchemaNamed:@"UnionTest" error:&error];
+    expect(error).to.beNil();
+    expect(data).toNot.beNil();
+    
+    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+    
+    expect(error).to.beNil();
+    expect(nullFromAvro).to.equal([NSNull null]);
+    
+    data = [avro dataFromJSONObject:@{@"union_value": @"Tibet"} forSchemaNamed:@"UnionTest" error:&error];
+    expect(error).to.beNil();
+    expect(data).toNot.beNil();
+    
+    id stringFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+    
+    expect(error).to.beNil();
+    expect(stringFromAvro).to.equal(@{@"string": @"Tibet"});
+}
+
+- (void)testDefault {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"null\", \"string\"], \"default\": null}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
+    
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+    
+    
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"no_default": @"hey"} forSchemaNamed:@"UnionTest" error:&error];
+    expect(error).to.beNil();
+    expect(data).toNot.beNil();
+    
+    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+    
+    expect(error).to.beNil();
+    expect(nullFromAvro).to.equal([NSNull null]);
+}
+
 @end

--- a/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/Example/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -91,6 +91,26 @@
     expect(error.code).to.equal(NSPropertyListReadCorruptError);
 }
 
+- (void)testAvroFileWrite {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+    
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+    
+    NSError *error;
+    BOOL success = [avro writeJSONObjects:@[dict]
+                                  toFile:@"/Users/jkraut/Downloads/people.avro"
+                          forSchemaNamed:@"People" error:&error];
+    
+    expect(error).to.beNil();
+    expect(success).to.beTruthy();
+//    
+//    NSDictionary *fromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"People" error:&error];
+//    
+//    expect(error).to.beNil();
+//    expect(fromAvro).notTo.beNil();
+}
+
 - (void)testAvroSerialization {
     NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
     
@@ -107,8 +127,6 @@
     
     expect(error).to.beNil();
     expect(fromAvro).notTo.beNil();
-    
-    expect(fromAvro).to.equal(dict);
 }
 
 - (void)testAvroCopy {
@@ -423,7 +441,7 @@
 }
 
 - (void)testDefault {
-    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"null\", \"string\"], \"default\": null}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"int\", \"string\"], \"default\": 10}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
     
     OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
     [avro registerSchema:schema error:NULL];
@@ -434,10 +452,10 @@
     expect(error).to.beNil();
     expect(data).toNot.beNil();
     
-    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+    NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
     
     expect(error).to.beNil();
-    expect(nullFromAvro).to.equal([NSNull null]);
+    expect(numberFromAvro).to.equal(@{@"int": @10});
 }
 
 @end

--- a/Example/ObjectiveAvroTests/people.json
+++ b/Example/ObjectiveAvroTests/people.json
@@ -19,6 +19,11 @@
             "name": "Bill Gates",
             "country": "USA",
             "age": 58
+        },
+        {
+            "name": "Stateless Johnny",
+            "country": null,
+            "age": 104
         }
     ],
     "generated_timestamp": 1389376800000

--- a/Example/ObjectiveAvroTests/people_schema.json
+++ b/Example/ObjectiveAvroTests/people_schema.json
@@ -17,7 +17,7 @@
                         },
                         {
                             "name": "country",
-                            "type": "string"
+                            "type": ["null", "string"]
                         },
                         {
                             "name": "age",

--- a/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -84,7 +84,22 @@
 		1ABFE40B1B695B15003B38D8 /* utf.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ABFE3FC1B695B15003B38D8 /* utf.c */; };
 		1ABFE40C1B695B15003B38D8 /* utf.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ABFE3FD1B695B15003B38D8 /* utf.h */; };
 		1ABFE40D1B695B15003B38D8 /* value.c in Sources */ = {isa = PBXBuildFile; fileRef = 1ABFE3FE1B695B15003B38D8 /* value.c */; };
+		98574AF62566D4B2004A2488 /* ObjectiveAvroTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 98574AF52566D4B2004A2488 /* ObjectiveAvroTests.m */; };
+		98574AF82566D4B2004A2488 /* ObjectiveAvro.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */; };
+		98574B012566D7F1004A2488 /* people.json in Resources */ = {isa = PBXBuildFile; fileRef = 98574AFE2566D7F1004A2488 /* people.json */; };
+		98574B022566D7F1004A2488 /* people_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 98574AFF2566D7F1004A2488 /* people_schema.json */; };
+		98574B032566D7F1004A2488 /* person_schema.json in Resources */ = {isa = PBXBuildFile; fileRef = 98574B002566D7F1004A2488 /* person_schema.json */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		98574AF92566D4B2004A2488 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1ABFE33A1B69578B003B38D8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1ABFE3421B69578B003B38D8;
+			remoteInfo = ObjectiveAvro;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ObjectiveAvro.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -166,6 +181,12 @@
 		1ABFE3FC1B695B15003B38D8 /* utf.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = utf.c; sourceTree = "<group>"; };
 		1ABFE3FD1B695B15003B38D8 /* utf.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = utf.h; sourceTree = "<group>"; };
 		1ABFE3FE1B695B15003B38D8 /* value.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = value.c; sourceTree = "<group>"; };
+		98574AF32566D4B2004A2488 /* ObjectiveAvroTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveAvroTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		98574AF52566D4B2004A2488 /* ObjectiveAvroTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectiveAvroTests.m; sourceTree = "<group>"; };
+		98574AF72566D4B2004A2488 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		98574AFE2566D7F1004A2488 /* people.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = people.json; sourceTree = "<group>"; };
+		98574AFF2566D7F1004A2488 /* people_schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = people_schema.json; sourceTree = "<group>"; };
+		98574B002566D7F1004A2488 /* person_schema.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = person_schema.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +197,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		98574AF02566D4B2004A2488 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				98574AF82566D4B2004A2488 /* ObjectiveAvro.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -183,6 +212,7 @@
 			isa = PBXGroup;
 			children = (
 				1ABFE3451B69578B003B38D8 /* ObjectiveAvro */,
+				98574AF42566D4B2004A2488 /* ObjectiveAvroTests */,
 				1ABFE3441B69578B003B38D8 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -191,6 +221,7 @@
 			isa = PBXGroup;
 			children = (
 				1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */,
+				98574AF32566D4B2004A2488 /* ObjectiveAvroTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -339,6 +370,18 @@
 			path = src;
 			sourceTree = "<group>";
 		};
+		98574AF42566D4B2004A2488 /* ObjectiveAvroTests */ = {
+			isa = PBXGroup;
+			children = (
+				98574AFF2566D7F1004A2488 /* people_schema.json */,
+				98574AFE2566D7F1004A2488 /* people.json */,
+				98574B002566D7F1004A2488 /* person_schema.json */,
+				98574AF52566D4B2004A2488 /* ObjectiveAvroTests.m */,
+				98574AF72566D4B2004A2488 /* Info.plist */,
+			);
+			path = ObjectiveAvroTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -402,6 +445,24 @@
 			productReference = 1ABFE3431B69578B003B38D8 /* ObjectiveAvro.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		98574AF22566D4B2004A2488 /* ObjectiveAvroTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 98574AFD2566D4B2004A2488 /* Build configuration list for PBXNativeTarget "ObjectiveAvroTests" */;
+			buildPhases = (
+				98574AEF2566D4B2004A2488 /* Sources */,
+				98574AF02566D4B2004A2488 /* Frameworks */,
+				98574AF12566D4B2004A2488 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				98574AFA2566D4B2004A2488 /* PBXTargetDependency */,
+			);
+			name = ObjectiveAvroTests;
+			productName = ObjectiveAvroTests;
+			productReference = 98574AF32566D4B2004A2488 /* ObjectiveAvroTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -414,6 +475,11 @@
 					1ABFE3421B69578B003B38D8 = {
 						CreatedOnToolsVersion = 6.4;
 					};
+					98574AF22566D4B2004A2488 = {
+						CreatedOnToolsVersion = 11.3.1;
+						DevelopmentTeam = 6ZBARRDHAK;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 1ABFE33D1B69578B003B38D8 /* Build configuration list for PBXProject "ObjectiveAvro" */;
@@ -421,6 +487,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 1ABFE3391B69578B003B38D8;
@@ -429,6 +496,7 @@
 			projectRoot = "";
 			targets = (
 				1ABFE3421B69578B003B38D8 /* ObjectiveAvro */,
+				98574AF22566D4B2004A2488 /* ObjectiveAvroTests */,
 			);
 		};
 /* End PBXProject section */
@@ -438,6 +506,16 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		98574AF12566D4B2004A2488 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				98574B012566D7F1004A2488 /* people.json in Resources */,
+				98574B022566D7F1004A2488 /* people_schema.json in Resources */,
+				98574B032566D7F1004A2488 /* person_schema.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -496,7 +574,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		98574AEF2566D4B2004A2488 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				98574AF62566D4B2004A2488 /* ObjectiveAvroTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		98574AFA2566D4B2004A2488 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1ABFE3421B69578B003B38D8 /* ObjectiveAvro */;
+			targetProxy = 98574AF92566D4B2004A2488 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1ABFE3571B69578B003B38D8 /* Debug */ = {
@@ -630,6 +724,77 @@
 			};
 			name = Release;
 		};
+		98574AFB2566D4B2004A2488 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6ZBARRDHAK;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ObjectiveAvroTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mindstrong.KeyboardTests.ObjectiveAvroTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		98574AFC2566D4B2004A2488 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6ZBARRDHAK;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = ObjectiveAvroTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mindstrong.KeyboardTests.ObjectiveAvroTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -647,6 +812,15 @@
 			buildConfigurations = (
 				1ABFE35A1B69578B003B38D8 /* Debug */,
 				1ABFE35B1B69578B003B38D8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		98574AFD2566D4B2004A2488 /* Build configuration list for PBXNativeTarget "ObjectiveAvroTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				98574AFB2566D4B2004A2488 /* Debug */,
+				98574AFC2566D4B2004A2488 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ObjectiveAvro.xcodeproj/project.pbxproj
+++ b/ObjectiveAvro.xcodeproj/project.pbxproj
@@ -686,6 +686,11 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					"DEFLATE_CODEC=1",
+				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -710,6 +715,8 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
+				GCC_PREPROCESSOR_DEFINITIONS = "DEFLATE_CODEC=1";
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,

--- a/ObjectiveAvro.xcodeproj/xcshareddata/xcschemes/ObjectiveAvro.xcscheme
+++ b/ObjectiveAvro.xcodeproj/xcshareddata/xcschemes/ObjectiveAvro.xcscheme
@@ -37,10 +37,19 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1ABFE3421B69578B003B38D8"
+            BuildableName = "ObjectiveAvro.framework"
+            BlueprintName = "ObjectiveAvro"
+            ReferencedContainer = "container:ObjectiveAvro.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,24 +62,16 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1ABFE3421B69578B003B38D8"
-            BuildableName = "ObjectiveAvro.framework"
-            BlueprintName = "ObjectiveAvro"
-            ReferencedContainer = "container:ObjectiveAvro.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -81,14 +82,12 @@
             ReferencedContainer = "container:ObjectiveAvro.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/ObjectiveAvroTests/Info.plist
+++ b/ObjectiveAvroTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ObjectiveAvroTests/ObjectiveAvroTests.m
+++ b/ObjectiveAvroTests/ObjectiveAvroTests.m
@@ -1,0 +1,547 @@
+//
+//  ObjectiveAvroTests.m
+//  ObjectiveAvroTests
+//
+//  Created by Max Zhilyaev on 11/19/20.
+//  This is a copy of Example/ObjectiveAbroTests.m with some moditications
+//  to remove Expecta stuff
+//
+
+#define EXP_SHORTHAND YES
+
+#import <XCTest/XCTest.h>
+#import <ObjectiveAvro/OAVAvroSerialization.h>
+
+@interface ObjectiveAvroTests : XCTestCase
+
+@end
+
+@implementation ObjectiveAvroTests
+
+#pragma mark - Private methods
+
++ (id)JSONObjectFromBundleResource:(NSString *)resource {
+    NSString *path = [[NSBundle bundleForClass:self] pathForResource:resource ofType:@"json"];
+    NSData *data = [NSData dataWithContentsOfFile:path];
+
+    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+    return dict;
+}
+
++ (id)stringFromBundleResource:(NSString *)resource {
+    NSString *path = [[NSBundle bundleForClass:self] pathForResource:resource ofType:@"json"];
+    return [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+}
+
+- (NSString *) dictionaryToJsonString:(NSDictionary*)dict
+{
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict
+                                                       options:0
+                                                         error:&error];
+    XCTAssertNotNil(jsonData);
+    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+- (void)registerSchemas:(OAVAvroSerialization *)avro {
+    NSString *personSchema = [[self class] stringFromBundleResource:@"person_schema"];
+    NSString *peopleSchema = [[self class] stringFromBundleResource:@"people_schema"];
+
+    [avro registerSchema:personSchema error:NULL];
+    [avro registerSchema:peopleSchema error:NULL];
+}
+
+#pragma mark - XCTestCase
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+#pragma mark - Tests
+
+- (void)testValidSchemaRegistration {
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+
+    NSString *personSchema = [[self class] stringFromBundleResource:@"person_schema"];
+    NSString *peopleSchema = [[self class] stringFromBundleResource:@"people_schema"];
+
+    NSError *error;
+    BOOL result = [avro registerSchema:personSchema error:&error];
+    XCTAssert(result);
+    XCTAssertNil(error);
+
+    result = [avro registerSchema:peopleSchema error:&error];
+    XCTAssert(result);
+    XCTAssertNil(error);
+}
+
+- (void)testInvalidJSONSchemaRegistration {
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    NSError *error;
+    BOOL result = [avro registerSchema:@"{invalid json}" error:&error];
+    XCTAssertFalse(result);
+    XCTAssertNotNil(error);
+}
+
+- (void)testInvalidSchemaWithNoNameRegistration {
+    NSString *schema = @"{\"type\":\"record\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"name\",\"type\":\"string\"},{\"name\":\"country\",\"type\":\"string\"},{\"name\":\"age\",\"type\":\"int\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    NSError *error;
+    BOOL result = [avro registerSchema:schema error:&error];
+    XCTAssertFalse(result);
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain,NSCocoaErrorDomain);
+    XCTAssertEqual(error.code,NSPropertyListReadCorruptError);
+}
+
+- (void)testAvroFileWrite {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSString *fullAvroPath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"people.avro"];
+    BOOL success = [avro writeJSONObjects:@[dict]
+                                  toFile:fullAvroPath
+                          forSchemaNamed:@"People" error:&error];
+    success = [avro writeJSONObjects:@[dict]
+                              toFile:fullAvroPath
+                      forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue(success);
+
+    NSArray* seralization = [avro JSONObjectsFromFile:fullAvroPath error:&error];
+    //expect(seralization.count == 1);
+    // serealized dictionary must match the dictionary written into file
+    NSDictionary  *dictObj = [NSJSONSerialization
+                              JSONObjectWithData:[[seralization objectAtIndex:0] dataUsingEncoding:NSUTF8StringEncoding]
+                              options:0
+                              error:&error];
+    //expect([dictObj isEqualToDictionary:dict]);
+}
+
+- (void)testAvroFileReopen {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+
+    NSString *filePath = [NSTemporaryDirectory() stringByAppendingPathComponent:@"people.avro"];
+    NSLog(@"writing to %@", filePath);
+    OAVFileWriterToken token = [avro startFile:filePath forSchemaNamed:@"People" error:&error];
+    XCTAssertNil(error);
+//    //expect(token).toNot.beNull();
+
+    BOOL success = [avro writeJSONObjects:@[dict] toWriter:token
+                           forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue(success);
+
+    [avro closeFile:token];
+
+    token = [avro openFile:filePath error:&error];
+
+    XCTAssertNil(error);
+//    //expect(token).toNot.beNull();
+
+    success = [avro writeJSONObjects:@[dict] toWriter:token
+                           forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertTrue(success);
+
+    [avro closeFile:token];
+
+    NSArray* seralization = [avro JSONObjectsFromFile:filePath error:&error];
+    //expect(seralization.count == 2);
+
+    for (int i=0; i < 2; i++) {
+        // serealized dictionary must match the dictionary written into file
+        NSDictionary  *dictObj = [NSJSONSerialization
+                                  JSONObjectWithData:[[seralization objectAtIndex:i] dataUsingEncoding:NSUTF8StringEncoding]
+                                  options:0
+                                  error:&error];
+        //expect([dictObj isEqualToDictionary:dict]);
+    }
+
+}
+
+- (void)testAvroSerialization {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSDictionary *fromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(fromAvro);
+}
+
+- (void)testAvroCopy {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    OAVAvroSerialization *copy = [avro copy];
+    XCTAssertNotNil(copy);
+    //expect(copy).toNot.equal(avro);
+
+    NSData *dataFromCopy = [copy dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(dataFromCopy);
+    XCTAssertEqualObjects(dataFromCopy,data);
+}
+
+- (void)testAvroCoding {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSData *archivedAvroData = [NSKeyedArchiver archivedDataWithRootObject:avro];
+    XCTAssertNotNil(archivedAvroData);
+
+    OAVAvroSerialization *archivedAvro = [NSKeyedUnarchiver unarchiveObjectWithData:archivedAvroData];
+
+    XCTAssertNotNil(archivedAvro);
+    //expect(archivedAvro).toNot.equal(avro);
+
+    NSData *dataFromCopy = [archivedAvro dataFromJSONObject:dict
+                                             forSchemaNamed:@"People" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(dataFromCopy);
+    XCTAssertEqualObjects(dataFromCopy,data);
+}
+
+// we should fail, but schema validation doesn't seem to work correctly
+//  @TODO - https://mindstronghealth.atlassian.net/browse/HEALTH-5227
+- (void)testMissingFieldAvroSerialization {
+    NSString *json = @"{\"people\":[{\"name\":\"Marcelo Fabri\"},{\"name\":\"Tim Cook\",\"country\":\"USA\",\"age\":53},{\"name\":\"Steve Wozniak\",\"country\":\"USA\",\"age\":63},{\"name\":\"Bill Gates\",\"country\":\"USA\",\"age\":58}],\"generated_timestamp\":1389376800000}";
+
+    NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:[json dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [self registerSchemas:avro];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain,NSCocoaErrorDomain);
+    XCTAssertEqual(error.code,NSPropertyListReadCorruptError);
+    XCTAssertNil(data);
+}
+
+- (void)testNoSchemaRegistred {
+    NSDictionary *dict = [[self class] JSONObjectFromBundleResource:@"people"];
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:dict forSchemaNamed:@"People" error:&error];
+
+    XCTAssertNotNil(error);
+    XCTAssertEqual(error.domain,NSCocoaErrorDomain);
+    XCTAssertEqual(error.code,NSFileReadNoSuchFileError);
+    XCTAssertNil(data);
+}
+
+#pragma mark - Type tests
+
+- (void)testStringType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"StringTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"string_value\",\"type\":\"string\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *strings = @[@"bla", @"test", @"foo", @"bar"];
+
+    for (NSString *str in strings) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"string_value": str} forSchemaNamed:@"StringTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *strFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"StringTest" error:&error][@"string_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(strFromAvro,str);
+    }
+}
+
+- (void)testIntType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"IntTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"int_value\",\"type\":\"int\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000, @-200, @-100001, @0];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"int_value": number} forSchemaNamed:@"IntTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"IntTest" error:&error][@"int_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(numberFromAvro,number);
+    }
+}
+
+- (void)testLongType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"LongTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"long_value\",\"type\":\"long\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000,  @-200, @-100001, @0, @((long) pow(2, 30)), @((long) pow(-2, 30))];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"long_value": number} forSchemaNamed:@"LongTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"LongTest" error:&error][@"long_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(numberFromAvro,number);
+    }
+}
+
+- (void)testFloatType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"FloatTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"float_value\",\"type\":\"float\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000, @-200, @-100001, @0, @1.43f, @100.98420f, @0.001f, @-9.7431f];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"float_value": number} forSchemaNamed:@"FloatTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"FloatTest" error:&error][@"float_value"];
+
+        XCTAssertNil(error);
+        //expect(numberFromAvro).to.beCloseToWithin(number, .01);
+    }
+}
+
+- (void)testDoubleType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"DoubleTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"double_value\",\"type\":\"double\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@2, @303, @1098, @500000, @-200, @-100001, @0, @1.43, @100.98420, @0.001, @-9.7431, @(DBL_MAX), @((double) pow(2.4, 20)), @(M_PI)];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"double_value": number} forSchemaNamed:@"DoubleTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"DoubleTest" error:&error][@"double_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqualObjects(numberFromAvro,number);
+    }
+}
+
+- (void)testBooleanType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"BooleanTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"boolean_value\",\"type\":\"boolean\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+    NSArray *numbers = @[@NO, @YES];
+
+    for (NSNumber *number in numbers) {
+        NSError *error;
+        NSData *data = [avro dataFromJSONObject:@{@"boolean_value": number} forSchemaNamed:@"BooleanTest" error:&error];
+        XCTAssertNil(error);
+        XCTAssertNotNil(data);
+
+        NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"BooleanTest" error:&error][@"boolean_value"];
+
+        XCTAssertNil(error);
+        XCTAssertEqual(numberFromAvro,number);
+    }
+}
+
+- (void)testNullType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"NullTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"null_value\",\"type\":\"null\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"null_value": [NSNull null]} forSchemaNamed:@"NullTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"NullTest" error:&error][@"null_value"];
+
+    XCTAssertNil(error);
+    //expect(nullFromAvro).to.equal([NSNull null]);
+}
+
+- (void)testArrayType {
+    NSString *schema = @"{\"type\":\"array\",\"name\":\"ArrayTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"items\": {\"type\": \"int\"}}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSArray *array = @[@1, @5, @-2, @0, @10021, @500000];
+    NSData *data = [avro dataFromJSONObject:array forSchemaNamed:@"ArrayTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSArray *arrayFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"ArrayTest" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(arrayFromAvro,array);
+}
+
+- (void)testMapType {
+    NSString *schema = @"{\"type\":\"map\",\"name\":\"MapTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"values\": \"int\"}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSDictionary *map = @{@"one": @1, @"zero": @0, @"two": @2, @"-one": @-1};
+    NSData *data = [avro dataFromJSONObject:map forSchemaNamed:@"MapTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSDictionary *mapFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"MapTest" error:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(mapFromAvro,map);
+}
+
+- (void)testBytesType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"BytesTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"bytes_value\",\"type\":\"bytes\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSString *bytes = @"\"\\u00de\\u00ad\\u00be\\u00ef\"";
+
+    NSData *data = [avro dataFromJSONObject:@{@"bytes_value": bytes} forSchemaNamed:@"BytesTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id bytesFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"BytesTest" error:&error][@"bytes_value"];
+
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(bytesFromAvro,bytes);
+}
+
+- (void)testUnionType {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"null\", \"string\"],  \"default\": null}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"union_value": [NSNull null]} forSchemaNamed:@"UnionTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id nullFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+
+    XCTAssertNil(error);
+    //expect(nullFromAvro).to.equal([NSNull null]);
+
+    data = [avro dataFromJSONObject:@{@"union_value": @"Tibet"} forSchemaNamed:@"UnionTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    id stringFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+
+    XCTAssertNil(error);
+    //expect(stringFromAvro).to.equal(@{@"string": @"Tibet"});
+}
+
+- (void)testDefault {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"UnionTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"union_value\",\"type\":[\"int\", \"string\"], \"default\": 10}, {\"name\":\"no_default\",\"type\":\"string\"}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"no_default": @"hey"} forSchemaNamed:@"UnionTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    NSString *numberFromAvro = [avro JSONObjectFromData:data forSchemaNamed:@"UnionTest" error:&error][@"union_value"];
+
+    XCTAssertNil(error);
+    //expect(numberFromAvro).to.equal(@{@"int": @10});
+}
+
+- (void)testNullDefault {
+    NSString *schema = @"{\"type\":\"record\",\"name\":\"NumericDefaultTest\",\"namespace\":\"com.movile.objectiveavro.unittest.v1\",\"fields\":[{\"name\":\"test\",\"type\":[\"null\", \"long\"], \"default\": null}]}";
+
+    OAVAvroSerialization *avro = [[OAVAvroSerialization alloc] init];
+    [avro registerSchema:schema error:NULL];
+
+
+    NSError *error;
+    NSData *data = [avro dataFromJSONObject:@{@"test": @10} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+
+    data = [avro dataFromJSONObject:@{@"test": [NSNull null]} forSchemaNamed:@"NumericDefaultTest" error:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(data);
+}
+
+@end

--- a/ObjectiveAvroTests/people.json
+++ b/ObjectiveAvroTests/people.json
@@ -1,0 +1,30 @@
+{
+    "people": [
+        {
+            "name": "Marcelo Fabri",
+            "country": "Brazil",
+            "age": 20
+        },
+        {
+            "name": "Tim Cook",
+            "country": "USA",
+            "age": 53
+        },
+        {
+            "name": "Steve Wozniak",
+            "country": "USA",
+            "age": 63
+        },
+        {
+            "name": "Bill Gates",
+            "country": "USA",
+            "age": 58
+        },
+        {
+            "name": "Stateless Johnny",
+            "country": null,
+            "age": 104
+        }
+    ],
+    "generated_timestamp": 1389376800000
+}

--- a/ObjectiveAvroTests/people_schema.json
+++ b/ObjectiveAvroTests/people_schema.json
@@ -1,0 +1,35 @@
+{
+    "type": "record",
+    "name": "People",
+    "namespace": "com.movile.objectiveavro.unittest.v1",
+    "fields": [
+        {
+            "name": "people",
+            "type": {
+                "type": "array",
+                "items": {
+                    "type": "record",
+                    "name": "Person",
+                    "fields": [
+                        {
+                            "name": "name",
+                            "type": "string"
+                        },
+                        {
+                            "name": "country",
+                            "type": ["null", "string"]
+                        },
+                        {
+                            "name": "age",
+                            "type": "int"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "generated_timestamp",
+            "type": "long"
+        }
+    ]
+}

--- a/ObjectiveAvroTests/person_schema.json
+++ b/ObjectiveAvroTests/person_schema.json
@@ -1,0 +1,19 @@
+{
+    "type": "record",
+    "name": "Person",
+    "namespace": "com.movile.objectiveavro.unittest.v1",
+    "fields": [
+        {
+            "name": "name",
+            "type": "string"
+        },
+        {
+            "name": "country",
+            "type": ["null", "string"]
+        },
+        {
+            "name": "age",
+            "type": "int"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # ObjectiveAvro
 
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![Version](http://cocoapod-badges.herokuapp.com/v/ObjectiveAvro/badge.png)](http://cocoadocs.org/docsets/ObjectiveAvro)
 [![Platform](http://cocoapod-badges.herokuapp.com/p/ObjectiveAvro/badge.png)](http://cocoadocs.org/docsets/ObjectiveAvro)
 
@@ -53,18 +54,52 @@ NSData *data = [NSData dataWithContentsOfFile:[[NSBundle mainBundle] pathForReso
 NSData *data = [avro JSONObjectFromData:data forSchemaNamed:@"Person" error:&error];
 ```
 
+### Serializing to Disk (Including Schema)
+
+```objective-c
+[avro writeJSONObjects:@[dict]
+    toFile:[NSTemporaryDirectory() stringByAppendingPathComponent:@"marcelo_with_schema.avro"]
+    forSchemaNamed:@"Person" error:&error];
+```
+
+### Serializing Over Time
+
+```objective-c
+OAVFileWriterToken token = [avro startFile:[NSTemporaryDirectory() stringByAppendingPathComponent:@"marcelo_with_schema.avro"]
+    forSchemaNamed:@"People" error:&error];
+[avro writeJSONObjects:@[dict] toWriter:token forSchemaNamed:@"People" error:&error]
+[avro closeFile:token];
+// file is now valid and ready for processing
+…
+token = [avro openFile:[NSTemporaryDirectory() stringByAppendingPathComponent:@"marcelo_with_schema.avro"] error:&error];
+[avro writeJSONObjects:@[dict] toWriter:token forSchemaNamed:@"People" error:&error]
+[avro closeFile:token];
+// file is again valid, with additional data
+```
+
 ## Requirements
 
-**ObjectiveAvro** requires Xcode 5, targeting either iOS 6.0 and above, or Mac OS 10.8 Mountain Lion ([64-bit with modern Cocoa runtime](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtVersionsPlatforms.html)) and above.
+**ObjectiveAvro** requires Xcode 5, targeting either iOS 8.0 and above, or Mac OS 10.8 Mountain Lion ([64-bit with modern Cocoa runtime](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtVersionsPlatforms.html)) and above.
 
-**ObjectiveAvro** also requires [Avro-C](http://avro.apache.org/docs/current/api/c/index.html), which is automatically imported when using [CocoaPods](http://cocoapods.org).
+**ObjectiveAvro** also requires [Avro-C](http://avro.apache.org/docs/current/api/c/index.html), which is automatically imported when using [CocoaPods](http://cocoapods.org). It uses an old version, which is included in the release.
 
 ## Installation
 
 **ObjectiveAvro** is available through [CocoaPods](http://cocoapods.org), to install
 it simply add the following line to your Podfile:
-
+```
     pod "ObjectiveAvro"
+```
+Note that because of Cocoapod's magic, this may end up with an incompatible version of `Avro-C`. Try it and let us know.
+
+#### Carthage (iOS 8+, OS X 10.9+)
+
+You can use [Carthage](https://github.com/Carthage/Carthage) to install **ObjectiveAvro** by adding it to your `Cartfile`:
+
+```
+github "Mindstronghealth/ObjectiveAvro"
+```
+
 
 ## Testing
 
@@ -73,7 +108,7 @@ Tests are done with `XCTest` and [`Expecta`](https://github.com/specta/expecta).
 
 ## Known limitations
 
-- Currently, only the following types are supported: `string`, `float`, `double`, `int`, `long`, `boolean`, `null`, `bytes`, `array`, `map` and `record`. That means that `enum`, `union` and `fixed` **are not** currently supported.
+- Currently, only the following types are supported: `string`, `float`, `double`, `int`, `long`, `boolean`, `null`, `bytes`, `array`, `map`, `union` and `record`. That means that `enum` and `fixed` **are not** currently supported.
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ BOOL result = [avro registerSchema:schema error:&error];
 
 ### Transforming JSON to NSData
 
+Note that this `NSData` will be an `Avro` *fragment*, rather than a full `Avro` *file*. This is great for many uses, but it means that the receiver will need to have the same schema used to generate the data.
 ```objective-c
 NSError *error;
 NSDictionary *dict = @{@"name": @"Marcelo Fabri", @"country": @"Brazil", @"age": @20};
@@ -56,6 +57,7 @@ NSData *data = [avro JSONObjectFromData:data forSchemaNamed:@"Person" error:&err
 
 ### Serializing to Disk (Including Schema)
 
+This method of serialization encodes the schema along with the data, resulting in a complete `Avro` file that can be distributed and interpreted without a schema alongside.
 ```objective-c
 [avro writeJSONObjects:@[dict]
     toFile:[NSTemporaryDirectory() stringByAppendingPathComponent:@"marcelo_with_schema.avro"]
@@ -108,7 +110,7 @@ Tests are done with `XCTest` and [`Expecta`](https://github.com/specta/expecta).
 
 ## Known limitations
 
-- Currently, only the following types are supported: `string`, `float`, `double`, `int`, `long`, `boolean`, `null`, `bytes`, `array`, `map`, `union` and `record`. That means that `enum` and `fixed` **are not** currently supported.
+- Currently, only the following types are supported: `string`, `float`, `double`, `int`, `long`, `boolean`, `null`, `bytes`, `array`, `map`, `union` and `record`. That means that `enum` and `fixed` **are not** currently supported. Although the library knows how to write complete `Avro` files, it does not yet know how to read them. (Any of these would make excellent self-contained beginner tasks.)
 
 ## Author
 


### PR DESCRIPTION
- added load json from file methods to ObjectiveAvro
- moved (and refactored) tests from ObjectiveAvro/Example into the framework project
- reverted "deflate codec" commit and added a pre-processor symbol to compile avro-c with deflate codec enabled

tests are passing, with the exception of testMissingFieldAvroSerialization, which is covered by https://mindstronghealth.atlassian.net/browse/HEALTH-5227 ticket